### PR TITLE
Remove mypy from CI/CD workflow

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -28,10 +28,6 @@ jobs:
       run: |
         black --check --diff .
     
-    - name: Type check with mypy
-      run: |
-        mypy l0
-    
     - name: Run tests with coverage
       run: |
         pytest tests/ -v --cov=l0 --cov-report=xml --cov-report=term-missing

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    removed:
+      - Removed mypy type checking from CI/CD workflow to eliminate type annotation overhead

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ dev = [
     "pytest>=7.0",
     "pytest-cov>=3.0",
     "black>=22.0",
-    "mypy>=0.900",
     "build>=1.3",
     "scikit-learn>=1.0",
     "yaml-changelog>=0.3.0",
@@ -61,14 +60,6 @@ Issues = "https://github.com/PolicyEngine/L0/issues"
 [tool.black]
 line-length = 79
 target-version = ['py313']
-
-
-[tool.mypy]
-python_version = "3.13"
-warn_return_any = true
-warn_unused_configs = true
-disallow_untyped_defs = true
-ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary
- Removes mypy type checking from the CI/CD pipeline
- Cleans up dev dependencies and configuration

## Rationale
The mypy type checker was causing CI failures due to strict type annotation requirements that added overhead without providing significant value for this project. Removing it simplifies the development workflow while maintaining code quality through other checks (black formatting, comprehensive tests).

## Changes
- Removed mypy step from GitHub Actions push workflow
- Removed mypy from dev dependencies in pyproject.toml
- Removed mypy configuration section

## Test plan
- [x] Verify CI passes without mypy
- [x] Confirm all other checks still run (black, pytest)
- [x] Package builds successfully

🤖 Generated with [Claude Code](https://claude.ai/code)