### PR TITLE
Mint GitHub App token in versioning workflow

### DIFF
--- a/.github/workflows/versioning.yaml
+++ b/.github/workflows/versioning.yaml
@@ -15,10 +15,16 @@ jobs:
         if: (github.event.head_commit.message != 'Update package version')
         runs-on: ubuntu-latest
         steps:
+          - name: Generate GitHub App token
+            id: app-token
+            uses: actions/create-github-app-token@v1
+            with:
+              app-id: ${{ secrets.APP_ID }}
+              private-key: ${{ secrets.APP_PRIVATE_KEY }}
           - name: Checkout repo
             uses: actions/checkout@v4
             with:
-              token: ${{ secrets.POLICYENGINE_GITHUB }}
+              token: ${{ steps.app-token.outputs.token }}
               fetch-depth: 0
           - name: Setup Python
             uses: actions/setup-python@v5
@@ -35,3 +41,5 @@ jobs:
             with:
               add: "."
               message: Update package version
+              github_token: ${{ steps.app-token.outputs.token }}
+              fetch: false

--- a/changelog.d/migrate-to-app-token.changed.md
+++ b/changelog.d/migrate-to-app-token.changed.md
@@ -1,0 +1,1 @@
+Migrated versioning workflow from expired POLICYENGINE_GITHUB PAT to GitHub App token (APP_ID/APP_PRIVATE_KEY).


### PR DESCRIPTION
## Summary

The org PAT `POLICYENGINE_GITHUB` expired on 2026-01-12. Migrate the versioning workflow to mint a short-lived GitHub App token via `actions/create-github-app-token@v1` using the org-installed App (`APP_ID` / `APP_PRIVATE_KEY`), matching the pattern applied across other PolicyEngine repos (microdf, policyengine-core, policyengine-us, etc.).

- Replaces `secrets.POLICYENGINE_GITHUB` with an App-minted token for the `actions/checkout@v4` step.
- Wires the same App token into `EndBug/add-and-commit@v9` (with `fetch: false`) so the automated "Update package version" commit is authored by the App and can push to `main`.

## Test plan

- [ ] YAML validates with `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/versioning.yaml'))"`
- [ ] CI passes on this PR
- [ ] After merge, next changelog.d change triggers `Versioning updates` and successfully pushes the version bump commit

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>